### PR TITLE
[FEAT] STOMP 연결 테스트

### DIFF
--- a/src/main/java/com/example/chatserver/chat/controller/StompController.java
+++ b/src/main/java/com/example/chatserver/chat/controller/StompController.java
@@ -1,19 +1,27 @@
 package com.example.chatserver.chat.controller;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @Controller
 public class StompController {
 
+//    메시지 브로커 역할
     @MessageMapping("/{roomId}")    // 클라이언트에서 특정 publish/roomId로 메시지 발행 시, MessageMapping이 수신
     @SendTo("/topic/{roomId}")      // 해당 roomId에 메시지를 발행하여 구독중인 클라이언트에게 메시지 전송
-    public void sendMessage(@DestinationVariable Long roomId, String message) {
+    public String sendMessage(@DestinationVariable Long roomId, String message) {
         // DestinationVariable : @MessageMapping 어노테이션으로 정의된 WebSocket Controller 내에서만 사용
+        log.info("📩 Received message in room {}: {}", roomId, message);
 
+        if (message == null || message.isBlank()) {
+            log.warn("⚠️ Empty message received in room {}", roomId);
+        }
+        log.info("📤 Broadcasting to /topic/{}", roomId);
+        return message;
     }
 
 }

--- a/src/main/java/com/example/chatserver/chat/controller/StompController.java
+++ b/src/main/java/com/example/chatserver/chat/controller/StompController.java
@@ -1,0 +1,26 @@
+package com.example.chatserver.chat.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
+@Controller
+public class StompController {
+
+    @MessageMapping("/{roomId}")    // 클라이언트에서 특정 publish/roomId로 메시지 발행 시, MessageMapping이 수신
+    @SendTo("/topic/{roomId}")      // 해당 roomId에 메시지를 발행하여 구독중인 클라이언트에게 메시지 전송
+    public void sendMessage(@DestinationVariable Long roomId, String message) {
+        // DestinationVariable : @MessageMapping 어노테이션으로 정의된 WebSocket Controller 내에서만 사용
+
+    }
+
+}
+
+/*
+    흐름
+    WebSocket Config
+    /publish/번호 -> message mapping 이 있는 곳으로 와서, room id가 값이 정해짐. 
+    
+ */

--- a/src/main/java/com/example/chatserver/common/configs/SecurityConfigs.java
+++ b/src/main/java/com/example/chatserver/common/configs/SecurityConfigs.java
@@ -41,7 +41,7 @@ public class SecurityConfigs {
                 // 특정 URL 패턴에 대해서는 Authentication 객체를 요구하지 않음 (인증 처리 제외)
                 .authorizeHttpRequests(auth -> auth
 //                        .requestMatchers("/**").permitAll()
-                        .requestMatchers("/connect" , "/api/members/signup",  "/api/auth/**").permitAll()
+                        .requestMatchers( "/api/members/signup",  "/api/auth/**", "/connect/**" ).permitAll()
                         .anyRequest().authenticated())  // 그 외 요청은 모두 인증 필요
 
                 // 세션 방식을 사용하지 않겠다.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,10 @@
 server:
   port: 5000
-
 spring:
   application:
     name: chat-practice
   config:
     import: classpath:secret.properties
-
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver


### PR DESCRIPTION
## 📌 개요
- Spring STOMP WebSocket 서버 기본 설정 추가
- 프론트(Vue)와 연결되는 `/connect` 엔드포인트 및 메시지 브로커 구성


## ✨ 주요 변경사항
- `StompWebSocketConfig.java` 추가
  - `/connect` 엔드포인트 등록 (SockJS 지원)
  - CORS 허용 오리진 `http://localhost:3000` 지정
  - 발행 prefix `/publish`, 구독 prefix `/topic` 설정
- `StompController.java` 생성
  - `@MessageMapping("/1")` → `/publish/1` 경로 메시지 처리
  - `@SendTo("/topic/1")` → 해당 방 구독자에게 메시지 브로드캐스트


## 🔍 테스트 방법
1. 서버 실행 (`localhost:5000`)
2. 프론트(Vue StompChatPage.vue)에서 `/connect` 엔드포인트를 통해 접속
3. `/publish/1` 경로로 메시지 발행 시 `/topic/1` 구독자 모두 메시지 수신 확인
